### PR TITLE
Fix modal close event not firing Fixes #1947

### DIFF
--- a/src/components/modal/Modal.vue
+++ b/src/components/modal/Modal.vue
@@ -186,7 +186,7 @@ export default {
         * Emit events, and destroy modal if it's programmatic.
         */
         close() {
-            this.$emit('close')
+            this.events.close && this.events.close()
             this.$emit('update:active', false)
 
             // Timeout for the animation complete before destroying


### PR DESCRIPTION
<!-- Thank you for helping Buefy! -->

Fixes #1947

## Proposed Changes

- remove the emit close which isn't working instead check to see if a close event is present if so call it
